### PR TITLE
Prevent a previously set ErrorLevel env var from preventing result codes

### DIFF
--- a/lib/ExtUtils/PL2Bat.pm
+++ b/lib/ExtUtils/PL2Bat.pm
@@ -29,6 +29,7 @@ sub pl2bat {
 	my $head = <<"EOT";
 	\@rem = '--*-Perl-*--
 	\@echo off
+	set ErrorLevel=
 	if "%OS%" == "Windows_NT" goto WinNT
 	perl $opts{otherargs}
 	\@set ErrorLevel=%ErrorLevel%


### PR DESCRIPTION
Turns out batch files need to clear the ErrorLevel env var, lest a prior batch file's results prevent correct result codes from this invocation.